### PR TITLE
Cache pip: install 60 -> 9 seconds, total 1m58s -> 1m12s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-python: 
+python:
   - 3.5
   - 3.6
 language: python
+cache: pip
 script: py.test
 after_failure: cat test/diffengine.log
 notifications:


### PR DESCRIPTION
# No cache enabled:

 Ran for 1 min 58 sec
 Total time 3 min 43 sec
 
59.76s `pip install -r requirements.txt`

https://travis-ci.org/hugovk/diffengine/jobs/210132306#L134

# Cache enabled, no cache created yet:

 Ran for 1 min 48 sec
 Total time 3 min 29 sec
 
49.62s `pip install -r requirements.txt`

# Cache enabled, using cache:

 Ran for 1 min 12 sec
 Total time 2 min 10 sec
 
9.07s `pip install -r requirements.txt`

https://travis-ci.org/hugovk/diffengine/jobs/210143455#L147