### PR TITLE
Set log level in config file

### DIFF
--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -329,14 +329,16 @@ class Diff(BaseModel):
 
 def setup_logging():
     path = config.get('log', home_path('diffengine.log'))
+    loglevel = config.get('loglevel', "INFO")
     logging.basicConfig(
-        level=logging.INFO,
+        level=loglevel,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         filename=path,
         filemode="a"
     )
     logging.getLogger("readability.readability").setLevel(logging.WARNING)
     logging.getLogger("tweepy.binder").setLevel(logging.WARNING)
+    logging.getLogger("peewee").setLevel(logging.WARNING)
 
 def load_config(prompt=True):
     global config
@@ -351,7 +353,7 @@ def load_config(prompt=True):
         yaml.dump(config, open(config_file, "w"), default_flow_style=False)
 
 def get_initial_config():
-    config = {"feeds": [], "phantomjs": "phantomjs"}
+    config = {"feeds": [], "phantomjs": "phantomjs", "loglevel": "INFO"}
 
     while len(config['feeds']) == 0:
         url = input("What RSS/Atom feed would you like to monitor? ")

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -144,7 +144,7 @@ class Entry(BaseModel):
         """
 
         # make sure we don't go too fast
-        time.sleep(1)
+        time.sleep(.5)
 
         # fetch the current readability-ized content for the page
         logging.info("checking %s", self.url)

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -43,7 +43,7 @@ class Feed(BaseModel):
     url = CharField(primary_key=True)
     name = CharField()
     created = DateTimeField(default=datetime.utcnow)
-    
+
     @property
     def entries(self):
         return (Entry.select()
@@ -100,10 +100,10 @@ class Entry(BaseModel):
                 .join(Entry)
                 .where(Entry.id==self.id))
 
-    @property   
+    @property
     def stale(self):
         """
-        A heuristic for checking new content very often, and checking 
+        A heuristic for checking new content very often, and checking
         older content less frequently. If an entry is deemed stale then
         it is worth checking again to see if the content has changed.
         """
@@ -133,10 +133,10 @@ class Entry(BaseModel):
 
     def get_latest(self):
         """
-        get_latest is the heart of the application. It will get the current 
-        version on the web, extract its summary with readability and compare 
-        it against a previous version. If a difference is found it will 
-        compute the diff, save it as html and png files, and tell Internet 
+        get_latest is the heart of the application. It will get the current
+        version on the web, extract its summary with readability and compare
+        it against a previous version. If a difference is found it will
+        compute the diff, save it as html and png files, and tell Internet
         Archive to create a snapshot.
 
         If a new version was found it will be returned, otherwise None will
@@ -175,7 +175,7 @@ class Entry(BaseModel):
         else:
             old = versions[0]
 
-        # compare what we got against the latest version and create a 
+        # compare what we got against the latest version and create a
         # new version if it looks different, or is brand new (no old version)
         new = None
 
@@ -470,7 +470,7 @@ def main():
     init(home)
     start_time = datetime.utcnow()
     logging.info("starting up with home=%s", home)
-    
+
     checked = skipped = new = 0
 
     for f in config.get('feeds', []):
@@ -480,7 +480,7 @@ def main():
 
         # get latest feed entries
         feed.get_latest()
-        
+
         # get latest content for each entry
         for entry in feed.entries:
             if not entry.stale:
@@ -494,7 +494,7 @@ def main():
                 tweet_diff(version.diff, f['twitter'])
 
     elapsed = datetime.utcnow() - start_time
-    logging.info("shutting down: new=%s checked=%s skipped=%s elapsed=%s", 
+    logging.info("shutting down: new=%s checked=%s skipped=%s elapsed=%s",
         new, checked, skipped, elapsed)
 
 def _dt(d):
@@ -508,7 +508,7 @@ def _normal(s):
     s = s.replace('”', '"')
     s = s.replace("’", "'")
     s = s.replace("\n", " ")
-    s = s.replace("­", "") 
+    s = s.replace("­", "")
     s = re.sub(r'  +', ' ', s)
     s = s.strip()
     return s
@@ -516,12 +516,12 @@ def _normal(s):
 def _equal(s1, s2):
     return _fingerprint(s1) == _fingerprint(s2)
 
-punctuation = dict.fromkeys(i for i in range(sys.maxunicode) 
+punctuation = dict.fromkeys(i for i in range(sys.maxunicode)
         if unicodedata.category(chr(i)).startswith('P'))
 
 def _fingerprint(s):
-    # make sure the string has been normalized, bleach everything, remove all 
-    # whitespace and punctuation to create a psuedo fingerprint for the text 
+    # make sure the string has been normalized, bleach everything, remove all
+    # whitespace and punctuation to create a psuedo fingerprint for the text
     # for use during compararison
     s = _normal(s)
     s = bleach.clean(s, tags=[], strip=True)

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -66,15 +66,21 @@ class Feed(BaseModel):
             return 0
         count = 0
         for e in feed.entries:
-            # note: look up with url only, because there may be 
+            # note: look up with url only, because there may be
             # overlap bewteen feeds, especially when a large newspaper
             # has multiple feeds
+            urlregex = config.get('urlregex', None)
+            if urlregex:
+                try:
+                    e.link = re.findall(urlregex, e.link)[0]
+                except IndexError:
+                    pass
             entry, created = Entry.get_or_create(url=e.link)
             if created:
                 FeedEntry.create(entry=entry, feed=self)
                 logging.info("found new entry: %s", e.link)
                 count += 1
-            elif len(entry.feeds.where(Feed.url == self.url)) == 0: 
+            elif len(entry.feeds.where(Feed.url == self.url)) == 0:
                 FeedEntry.create(entry=entry, feed=self)
                 logging.debug("found entry from another feed: %s", e.link)
                 count += 1


### PR DESCRIPTION
Defaults to INFO, both on read (to make sure that old setups without the value in config.yaml don’t fail) and generation of new config file.
Sets the peewee logger to WARNING