### PR TITLE
Attempt to optimize version querying by adding a limit statement

### DIFF
--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -162,8 +162,7 @@ class Entry(BaseModel):
         canonical_url = _remove_utm(resp.url)
 
         # get the latest version, if we have one
-        versions = EntryVersion.select().where(EntryVersion.url==canonical_url)
-        versions = versions.order_by(-EntryVersion.created)
+        versions = EntryVersion.select().where(EntryVersion.url==canonical_url).order_by(-EntryVersion.created).limit(1)
         if len(versions) == 0:
             old = None
         else:


### PR DESCRIPTION
In looking at my diffengine instances with large SQLite databases, by using [py-spy](https://github.com/benfred/py-spy) I noticed that they were spending almost all their time executing the `versions` SQL query. Since we only use one result, adding `limit(1)` to the query may significantly improve performance (particularly for large databases).