### PR TITLE
Updated archive URLs.

### DIFF
--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -247,7 +247,7 @@ class EntryVersion(BaseModel):
             resp = _get(save_url)
             wayback_id = resp.headers.get("Content-Location")
             if wayback_id:
-                self.archive_url = "https://wayback.archive.org" + wayback_id
+                self.archive_url = "https://web.archive.org" + wayback_id
                 logging.debug("archived version at %s", self.archive_url)
                 self.save()
                 return self.archive_url


### PR DESCRIPTION
wayback.archive.org URLs are no longer functional. Updated to generate web.archive.org URLs instead.