### PR TITLE
CLI command for generating tokens for extra twitter accounts

### DIFF
--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -383,7 +383,7 @@ def get_auth_link_and_show_token():
     token = request_pin_to_user_and_get_token(
         twitter["consumer_key"], twitter["consumer_secret"]
     )
-    print("These are your access token and secret.\nDO NOT SHARE THEM WITH ANYONE!\n")
+    print("\nThese are your access token and secret.\nDO NOT SHARE THEM WITH ANYONE!\n")
     print("ACCESS_TOKEN\n%s\n" % token[0])
     print("ACCESS_TOKEN_SECRET\n%s\n" % token[1])
 

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -375,6 +375,19 @@ def load_config(prompt=True):
     return config
 
 
+def get_auth_link_and_show_token():
+    global home
+    home = os.getcwd()
+    config = load_config(True)
+    twitter = config["twitter"]
+    token = request_pin_to_user_and_get_token(
+        twitter["consumer_key"], twitter["consumer_secret"]
+    )
+    print("These are your access token and secret.\nDO NOT SHARE THEM WITH ANYONE!\n")
+    print("ACCESS_TOKEN\n%s\n" % token[0])
+    print("ACCESS_TOKEN_SECRET\n%s\n" % token[1])
+
+
 def get_initial_config():
     config = {"feeds": []}
 
@@ -594,25 +607,12 @@ def _get(url, allow_redirects=True):
     )
 
 
-def get_auth_link_and_show_token():
-    global home
-    home = os.getcwd()
-    config = load_config(True)
-    twitter = config["twitter"]
-    token = request_pin_to_user_and_get_token(
-        twitter["consumer_key"], twitter["consumer_secret"]
-    )
-    print("These are your access token and secret.\nDO NOT SHARE THEM WITH ANYONE!\n")
-    print("ACCESS_TOKEN\n%s\n" % token[0])
-    print("ACCESS_TOKEN_SECRET\n%s\n" % token[1])
-
-
 # Cli options
 parser = argparse.ArgumentParser()
 parser.add_argument("--add", action="store_true")
+options = parser.parse_args()
 
 if __name__ == "__main__":
-    options = parser.parse_args()
     if options.add:
         get_auth_link_and_show_token()
     else:

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -607,12 +607,12 @@ def _get(url, allow_redirects=True):
     )
 
 
-# Cli options
-parser = argparse.ArgumentParser()
-parser.add_argument("--add", action="store_true")
-options = parser.parse_args()
-
 if __name__ == "__main__":
+    # Cli options
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--add", action="store_true")
+    options = parser.parse_args()
+
     if options.add:
         get_auth_link_and_show_token()
     else:


### PR DESCRIPTION
You can now execute diffinengine with `--add` flag to receive the Twitter auth URL and use it for getting the tokens for the account you wanna add to the config yaml.

Usage example

```
$ diffengine --add

Log in to https://twitter.com as the user you want to tweet as and hit enter.
Visit https://api.twitter.com/oauth/authorize?oauth_token=QKGAqgAAAAABDsonAAABcbfQfFw in your browser and hit enter.
What is your PIN: 1234567

These are your access token and secret.
DO NOT SHARE THEM WITH ANYONE!

access_token
xxxxxxxxxxx-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy

access_token_secret
zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
```

This way you can copy&paste the token in your own `config.yaml` file