### PR TITLE
Configurable webdriver (gecko by default but now chrome can be chosen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,85 @@ MY_CONSUMER_SECRET_ENV_VAR="CONSUMER_SECRET"
 
 Done! You can use diffengine as usual and keep your credentials safe.
 
+## Adding a Twitter account when the configuration file is already created
+
+You can use the following command for adding Twitter accounts to the config file.
+
+```shell script
+$ diffengine --add
+
+Log in to https://twitter.com as the user you want to tweet as and hit enter.
+Visit https://api.twitter.com/oauth/authorize?oauth_token=QKGAqgAAAAABDsonAAABcbfQfFw in your browser and hit enter.
+What is your PIN: 1234567
+
+These are your access token and secret.
+DO NOT SHARE THEM WITH ANYONE!
+
+ACCESS_TOKEN
+xxxxxxxxxxx-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+
+ACCESS_TOKEN_SECRET
+zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+```
+
+Then you would use the `ACCESS_TOKEN` and the `ACCESS_TOKEN_SECRET` inside the config like this
+
+```shell script
+feeds:
+- name: My new feed
+  url: http://www.mynewfeed.com/feed/
+  twitter:
+    access_token: "${ACCESS_TOKEN}"
+    access_token_secret: "${ACCESS_TOKEN_SECRET}"
+```
+
+### Avaiable webdriver engines
+
+Diffengine has support for `geckodriver` and `chromedriver`.
+
+You can configure this in the `config.yaml`. The keys are the following ones.
+```yml
+webdriver:
+  engine:
+  executable_path:
+  binary_location:
+```
+
+#### Configuring geckodriver
+
+The `geckodriver` is properly defined by default. In case you need to configure it, then:
+
+```yml
+webdriver:
+  engine: "geckodriver"
+  executable_path: null (this config has no use with geckodriver)
+  binary_location: null (the same as above with this one)
+```
+
+#### Configuring chromedriver
+
+If you want to use `chromedriver` locally, then you should leave the config this way:
+
+```yml
+webdriver:
+  engine: "chromedriver"
+  executable_path: null ("chromedriver" by default)
+  binary_location: null ("" by default)
+```
+
+##### Using chromedriver in Heroku
+
+If you use Heroku, then you have to add the [Heroku chromedriver buildpack](https://github.com/heroku/heroku-buildpack-chromedriver).
+And then use the environment vars provided automatically by it.
+
+```yml
+webdriver:
+  engine: "chromedriver"
+  executable_path: "${CHROMEDRIVER_PATH}"
+  binary_location: "${GOOGLE_CHROME_BIN}"
+```
+
+
 ## Develop
 
 [![Build Status](https://travis-ci.org/DocNow/diffengine.svg)](http://travis-ci.org/DocNow/diffengine)

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -30,9 +30,12 @@ from peewee import *
 from playhouse.migrate import SqliteMigrator, migrate
 from datetime import datetime, timedelta
 from selenium import webdriver
-from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
+from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
+from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 from envyaml import EnvYAML
+
+from diffengine.exceptions import UnknownWebdriverError
 
 home = None
 config = {}
@@ -364,7 +367,9 @@ def load_config(prompt=True):
     config_file = os.path.join(home, "config.yaml")
     env_file = home_path(".env")
     if os.path.isfile(config_file):
-        config = EnvYAML(config_file, env_file=env_file)
+        config = EnvYAML(
+            config_file, env_file=env_file if os.path.isfile(env_file) else None
+        )
     else:
         if not os.path.isdir(home):
             os.makedirs(home)
@@ -432,15 +437,37 @@ def setup_db():
         logging.debug(e)
 
 
-def setup_browser():
-    global browser
+def chromedriver_browser(executable_path, binary_location):
+    options = ChromeOptions()
+    options.binary_location = binary_location
+    options.add_argument("--headless")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--no-sandbox")
+    return webdriver.Chrome(executable_path=executable_path, options=options)
 
-    if not shutil.which("geckodriver"):
-        sys.exit("Please install geckodriver and make sure it is in your PATH.")
 
+def geckodriver_browser():
     opts = FirefoxOptions()
     opts.headless = True
-    browser = webdriver.Firefox(options=opts)
+    return webdriver.Firefox(options=opts)
+
+
+def setup_browser(engine="geckodriver", executable_path=None, binary_location=""):
+    global browser
+
+    if engine not in ["chromedriver", "geckodriver"]:
+        raise UnknownWebdriverError(engine)
+
+    if not shutil.which(engine):
+        sys.exit("Please install %s and make sure it is in your PATH." % engine)
+
+    if engine == "chromedriver":
+        return chromedriver_browser(
+            engine if executable_path is None else executable_path, binary_location
+        )
+
+    if engine == "geckodriver":
+        return geckodriver_browser()
 
 
 def tweet_diff(diff, token):
@@ -479,12 +506,19 @@ def tweet_diff(diff, token):
 
 
 def init(new_home, prompt=True):
-    global home
+    global home, browser
     home = new_home
     load_config(prompt)
-    setup_browser()
-    setup_logging()
-    setup_db()
+    try:
+        # by defualt keep using geckodriver
+        engine = config.get("webdriver.engine", "geckodriver")
+        executable_path = config.get("webdriver.executable_path")
+        binary_location = config.get("webdriver.binary_location")
+        browser = setup_browser(engine, executable_path, binary_location)
+        setup_logging()
+        setup_db()
+    except RuntimeError as e:
+        logging.error("Could not finish the setup", e)
 
 
 def main():

--- a/diffengine/exceptions.py
+++ b/diffengine/exceptions.py
@@ -1,0 +1,12 @@
+class UnknownWebdriverError(RuntimeError):
+    """Exception raised if the indicated webdriver is unknown
+
+    Attributes:
+        driver -- the indicated webdriver in the configuratoin file
+    """
+
+    def __init__(self, driver):
+        self.message = (
+            'webdriver "%s" is not a valid engine. Please indicate one of "chromedriver" or "geckodriver" and restart the process.'
+            % driver
+        )

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -159,3 +159,27 @@ def test_environment_vars_in_config_file():
     assert new_config["example"]["public_value"] == public_value
     assert new_config["example"]["private_value"] != private_yaml_key
     assert new_config["example"]["private_value"] == private_value
+
+
+def test_geckodriver_when_webdriver_is_not_defined():
+    # create config.yaml that will be read
+    browser = setup_browser()
+    assert isinstance(browser, webdriver.Firefox) == True
+
+
+def test_raises_when_unknown_webdriver():
+    with pytest.raises(UnknownWebdriverError):
+        # create config.yaml that will be read
+        setup_browser("wrong_engine")
+
+
+def test_webdriver_is_geckodriver():
+    # create config.yaml that will be read
+    browser = setup_browser("geckodriver")
+    assert isinstance(browser, webdriver.Firefox) == True
+
+
+def test_webdriver_is_chromedriver():
+    # create config.yaml that will be read
+    browser = setup_browser("chromedriver")
+    assert isinstance(browser, webdriver.Chrome) == True


### PR DESCRIPTION
I've added the chromedriver configurable with the `config.yaml` file.

You can configure this in the `config.yaml`. The keys are the following ones.
```yml
webdriver:
  engine:
  executable_path:
  binary_location:
```

## Geckodriver

The `geckodriver` is properly defined by default. In case you need to configure it, then:

```yml
webdriver:
  engine: "geckodriver"
  executable_path: null (this config has no use with geckodriver)
  binary_location: null (the same as above with this one)
```

## Chromedriver

If you want to use `chromedriver` locally, then you should leave the config this way:

```yml
webdriver:
  engine: "chromedriver"
  executable_path: null ("chromedriver" by default)
  binary_location: null ("" by default)
```

## Using chromedriver in Heroku

If you use Heroku, then you have to add the [Heroku chromedriver buildpack](https://github.com/heroku/heroku-buildpack-chromedriver).
And then use the environment vars provided automatically by it.

```yml
webdriver:
  engine: "chromedriver"
  executable_path: "${CHROMEDRIVER_PATH}"
  binary_location: "${GOOGLE_CHROME_BIN}"
```

**This is added in the readme**