### PR TITLE
Configurable tweet text

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,29 @@ Logs can be found in `diffengine.log` in the storage directory, for example
 Checkout [Ryan Baumann's "diffengine" Twitter list] for a list of known
 diffengine Twitter accounts that are out there.
 
+## Tweeting text options
+
+By default, the tweeted diff will include the article's title and the archive diff url, [like this](https://twitter.com/mp_diff/status/1255973684994625539).
+
+You change this by tweeting what's changed: the url, the title and/or the summary. For doing so, you need to specify **all** the following `lang` keys:
+
+```yaml
+lang:
+  change_in: "Change in"
+  the_url: "the URL"
+  the_title: "the title"
+  and: "and"
+  the_summary: "the summary"
+```
+
+Only if all the keys are defined, the tweet will include what's changed on its content, followed by the `diff.url`. Some examples:
+
+- "Change in the title"
+- "Change in the summary"
+- "Change in the title and the summary"
+
+And so on with all the possible combinations between url, title and summary
+
 ## Multiple Accounts & Feed Implementation Example
 
 If you are setting multiple accounts, and multiple feeds if may be helpful to setup a
@@ -157,7 +180,7 @@ Done! You can use diffengine as usual and keep your credentials safe.
 
 You can use the following command for adding Twitter accounts to the config file.
 
-```shell script
+```shell
 $ diffengine --add
 
 Log in to https://twitter.com as the user you want to tweet as and hit enter.

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -149,6 +149,7 @@ class Entry(BaseModel):
         """
 
         # make sure we don't go too fast
+        # TODO: can we remove this? Why is this here?
         time.sleep(1)
 
         # fetch the current readability-ized content for the page

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -537,6 +537,7 @@ def main():
     init(home)
     start_time = datetime.utcnow()
     logging.info("starting up with home=%s", home)
+    lang = config.get("lang")
 
     try:
         twitter_config = config.get("twitter")
@@ -562,7 +563,7 @@ def main():
 
         # get latest content for each entry
         for entry in feed.entries:
-            result = process_entry(entry, f["twitter"], twitter_handler)
+            result = process_entry(entry, twitter_handler, lang)
             skipped += result["skipped"]
             checked += result["checked"]
             new += result["new"]

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -75,7 +75,7 @@ class Feed(BaseModel):
             resp = _get(self.url)
             feed = feedparser.parse(resp.text)
         except Exception as e:
-            logging.error("unable to fetch feed %s: %s", self.url, e)
+            logging.error("unable to fetch feed %s: %s", self.url, str(e))
             return 0
         count = 0
         for e in feed.entries:
@@ -156,7 +156,7 @@ class Entry(BaseModel):
         try:
             resp = _get(self.url)
         except Exception as e:
-            logging.error("unable to fetch %s: %s", self.url, e)
+            logging.error("unable to fetch %s: %s", self.url, str(e))
             return None
 
         if resp.status_code != 200:
@@ -278,7 +278,9 @@ class EntryVersion(BaseModel):
                 )
 
         except Exception as e:
-            logging.error("unexpected archive.org response for %s: %s", save_url, e)
+            logging.error(
+                "unexpected archive.org response for %s: %s", save_url, str(e)
+            )
         return None
 
 
@@ -525,7 +527,7 @@ def init(new_home, prompt=True):
         )
         setup_db()
     except RuntimeError as e:
-        logging.error("Could not finish the setup", e)
+        logging.error("Could not finish the setup", str(e))
 
 
 def main():
@@ -594,11 +596,11 @@ def process_entry(entry, token=None, twitter_handler=None, lang={}):
                     try:
                         twitter_handler.tweet_diff(version.diff, token, lang)
                     except TwitterError as e:
-                        logging.warning("error occurred while trying to tweet", e)
+                        logging.warning("error occurred while trying to tweet", str(e))
                     except Exception as e:
-                        logging.error("unknown error when tweeting diff", e)
+                        logging.error("unknown error when tweeting diff", str(e))
         except Exception as e:
-            logging.error("unable to get latest", e)
+            logging.error("unable to get latest", str(e))
     return result
 
 

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -537,7 +537,7 @@ def main():
     init(home)
     start_time = datetime.utcnow()
     logging.info("starting up with home=%s", home)
-    lang = config.get("lang")
+    lang = config.get("lang", {})
 
     try:
         twitter_config = config.get("twitter")
@@ -563,7 +563,7 @@ def main():
 
         # get latest content for each entry
         for entry in feed.entries:
-            result = process_entry(entry, twitter_handler, lang)
+            result = process_entry(entry, f["twitter"], twitter_handler, lang)
             skipped += result["skipped"]
             checked += result["checked"]
             new += result["new"]
@@ -580,7 +580,7 @@ def main():
     browser.quit()
 
 
-def process_entry(entry, token=None, twitter=None):
+def process_entry(entry, token=None, twitter_handler=None, lang={}):
     result = {"skipped": 0, "checked": 0, "new": 0}
     if not entry.stale:
         result["skipped"] = 1
@@ -592,7 +592,7 @@ def process_entry(entry, token=None, twitter=None):
                 result["new"] = 1
                 if version.diff and token is not None:
                     try:
-                        twitter.tweet_diff(version.diff, token)
+                        twitter_handler.tweet_diff(version.diff, token, lang)
                     except TwitterError as e:
                         logging.warning("error occurred while trying to tweet", e)
                     except Exception as e:

--- a/diffengine/text_builder.py
+++ b/diffengine/text_builder.py
@@ -1,27 +1,30 @@
 import logging
 
 
-def build_text(diff, lang):
-    logging.debug("building text for diff %s" % diff.new.title)
+def build_text(diff, lang={}):
     # Try build the text from i18n
     if can_build_with_lang(lang):
-        logging.debug("with lang")
+        logging.debug("building text with lang")
         return "%s\n%s" % (
-            build_from_lang(
+            build_with_lang(
                 lang, diff.url_changed, diff.title_changed, diff.summary_changed
             ),
             diff.url,
         )
+    elif lang:
+        logging.warning(
+            "cannot build text from lang. Check you have ALL the keys: 'change_in', 'the_url', 'the_title' and 'the_summary'"
+        )
 
-    logging.debug("with default text")
-    return build_default(diff)
+    logging.debug("building text with default content")
+    return build_with_default_content(diff)
 
 
 def can_build_with_lang(lang):
     return all(k in lang for k in ("change_in", "the_url", "the_title", "the_summary"))
 
 
-def build_from_lang(lang, url_changed, title_changed, summary_changed):
+def build_with_lang(lang, url_changed, title_changed, summary_changed):
     changes = []
     if url_changed:
         changes.append(lang["the_url"])
@@ -45,7 +48,7 @@ def build_from_lang(lang, url_changed, title_changed, summary_changed):
     )
 
 
-def build_default(diff):
+def build_with_default_content(diff):
     text = diff.new.title
     if len(text) >= 225:
         text = text[0:225] + "…"

--- a/diffengine/text_builder.py
+++ b/diffengine/text_builder.py
@@ -21,10 +21,14 @@ def build_text(diff, lang={}):
 
 
 def can_build_with_lang(lang):
-    return all(k in lang for k in ("change_in", "the_url", "the_title", "the_summary"))
+    return all(
+        k in lang for k in ("change_in", "the_url", "the_title", "and", "the_summary")
+    )
 
 
-def build_with_lang(lang, url_changed, title_changed, summary_changed):
+def build_with_lang(
+    lang, url_changed=False, title_changed=False, summary_changed=False
+):
     changes = []
     if url_changed:
         changes.append(lang["the_url"])

--- a/diffengine/text_builder.py
+++ b/diffengine/text_builder.py
@@ -1,0 +1,53 @@
+import logging
+
+
+def build_text(diff, lang):
+    logging.debug("building text for diff %s" % diff.new.title)
+    # Try build the text from i18n
+    if can_build_with_lang(lang):
+        logging.debug("with lang")
+        return "%s\n%s" % (
+            build_from_lang(
+                lang, diff.url_changed, diff.title_changed, diff.summary_changed
+            ),
+            diff.url,
+        )
+
+    logging.debug("with default text")
+    return build_default(diff)
+
+
+def can_build_with_lang(lang):
+    return all(k in lang for k in ("change_in", "the_url", "the_title", "the_summary"))
+
+
+def build_from_lang(lang, url_changed, title_changed, summary_changed):
+    changes = []
+    if url_changed:
+        changes.append(lang["the_url"])
+    if title_changed:
+        changes.append(lang["the_title"])
+    if summary_changed:
+        changes.append(lang["the_summary"])
+
+    if len(changes) > 1:
+        and_change = " %s " % lang["and"]
+        last_change = changes.pop(len(changes) - 1)
+    else:
+        and_change = ""
+        last_change = ""
+
+    return "%s %s%s%s" % (
+        lang["change_in"],
+        ", ".join(changes),
+        and_change,
+        last_change,
+    )
+
+
+def build_default(diff):
+    text = diff.new.title
+    if len(text) >= 225:
+        text = text[0:225] + "…"
+    text += " " + diff.url
+    return text

--- a/diffengine/twitter.py
+++ b/diffengine/twitter.py
@@ -57,9 +57,9 @@ class TwitterHandler:
         if not token:
             raise TokenNotFoundError()
         elif diff.tweeted:
-            raise AlreadyTweetedError(diff.id)
+            raise AlreadyTweetedError(diff)
         elif not (diff.old.archive_url and diff.new.archive_url):
-            raise AchiveUrlNotFoundError()
+            raise AchiveUrlNotFoundError(diff)
 
         twitter = self.api(token)
         text = build_text(diff, lang)

--- a/diffengine/twitter.py
+++ b/diffengine/twitter.py
@@ -3,6 +3,7 @@ import tweepy
 
 from datetime import datetime
 
+from diffengine.text_builder import build_text
 from exceptions.twitter import (
     AlreadyTweetedError,
     ConfigNotFoundError,
@@ -52,7 +53,7 @@ class TwitterHandler:
         except Exception as e:
             raise UpdateStatusError(entry)
 
-    def tweet_diff(self, diff, token=None):
+    def tweet_diff(self, diff, token=None, lang=None):
         if not token:
             raise TokenNotFoundError()
         elif diff.tweeted:
@@ -61,7 +62,7 @@ class TwitterHandler:
             raise AchiveUrlNotFoundError()
 
         twitter = self.api(token)
-        text = self.build_text(diff)
+        text = build_text(diff, lang)
 
         # Check if the thread exists
         thread_status_id_str = None

--- a/diffengine/twitter.py
+++ b/diffengine/twitter.py
@@ -53,7 +53,7 @@ class TwitterHandler:
         except Exception as e:
             raise UpdateStatusError(entry)
 
-    def tweet_diff(self, diff, token=None, lang=None):
+    def tweet_diff(self, diff, token=None, lang={}):
         if not token:
             raise TokenNotFoundError()
         elif diff.tweeted:

--- a/exceptions/twitter.py
+++ b/exceptions/twitter.py
@@ -17,13 +17,13 @@ class TokenNotFoundError(TwitterError):
 
 
 class AlreadyTweetedError(TwitterError):
-    def __init__(self, diff_id):
-        self.message = "diff %s has already been tweeted" % diff_id
+    def __init__(self, diff):
+        self.message = "diff %s has already been tweeted" % diff.id
 
 
 class AchiveUrlNotFoundError(TwitterError):
-    def __init__(self):
-        self.message = "not tweeting without archive urls"
+    def __init__(self, diff):
+        self.message = "not tweeting without archive urls for diff %s" % diff.id
 
 
 class UpdateStatusError(TwitterError):

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -538,7 +538,7 @@ class TextBuilderTest(TestCase):
         type(diff.new).title = PropertyMock(return_value="Test")
         type(diff).url = PropertyMock(return_value="https://this.is/a-test")
 
-        text = build_text(diff)
+        build_text(diff)
 
         mocked_warning.assert_not_called()
         mocked_build_with_default_content.assert_called_once()
@@ -598,12 +598,6 @@ class TextBuilderTest(TestCase):
 
         mocked_build_from_lang.assert_not_called()
         self.assertEqual(text, "%s %s" % (diff.new.title, diff.url))
-
-    @patch("diffengine.text_builder.build_with_lang")
-    def test_default_content_text_when_lang_is_incomplete(self, mocked_build_from_lang):
-        diff = get_mocked_diff()
-        type(diff.new).title = "Test"
-        type(diff).url = "https://this.is/a-test"
 
         lang = {
             "change_in": "change in",

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -409,30 +409,6 @@ class TwitterHandlerTest(TestCase):
         mocked_get_username.assert_called()
 
     @patch("tweepy.OAuthHandler.get_username", return_value="test_user")
-    @patch("diffengine.TwitterHandler.create_thread")
-    def test_update_thread_if_old_entry_has_related_tweet(
-        self, mocked_create_thread, mocked_get_username
-    ):
-
-        entry = MagicMock()
-        type(entry).tweet_status_id_str = PropertyMock(return_value="1234567890")
-
-        diff = get_mocked_diff()
-        type(diff.old).entry = entry
-
-        twitter = TwitterHandler("myConsumerKey", "myConsumerSecret")
-        twitter.tweet_diff(
-            diff,
-            {
-                "access_token": "myAccessToken",
-                "access_token_secret": "myAccessTokenSecret",
-            },
-        )
-
-        mocked_create_thread.assert_not_called()
-        mocked_get_username.assert_called_once()
-
-    @patch("tweepy.OAuthHandler.get_username", return_value="test_user")
     @patch("tweepy.API.update_with_media", return_value=MockedStatus)
     def test_update_thread_if_old_entry_has_related_tweet(
         self, mocked_update_with_media, mocked_get_username


### PR DESCRIPTION
Now, the tweets can differentiate what changed between both versions: the URL, the title and/or the summary.

For accomplish that, a new config is added

```yaml
lang:
  change_in: "Change in"
  the_url: "the URL"
  the_title: "the title"
  and: "and"
  the_summary: "the summary"
```

Only if all the keys are defined in the `lang` dict inside the `config.yaml` then the tweet will include what's changed followed by the `diff.url`. The following are examples for the texts -in spanish with the old url, this PR will includes the new diff url-

- [Change in the title](https://twitter.com/ep_diff/status/1256492141033000961)
- [Change in the summary](https://twitter.com/ep_diff/status/1255761835518812160)
- [Change in the title and the summary](https://twitter.com/ep_diff/status/1256388446740000771)

Also applies for URL changes, but I didn't see any event in real life yet.