### PR TITLE
Add sendgrid support to send emails

### DIFF
--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -104,7 +104,7 @@ class Entry(BaseModel):
     url = CharField()
     created = DateTimeField(default=datetime.utcnow)
     checked = DateTimeField(default=datetime.utcnow)
-    tweet_status_id_str = CharField(null=True)
+    tweet_status_id_str = CharField(null=False, default="")
 
     @property
     def feeds(self):
@@ -236,7 +236,7 @@ class EntryVersion(BaseModel):
     created = DateTimeField(default=datetime.utcnow)
     archive_url = CharField(null=True)
     entry = ForeignKeyField(Entry, backref="versions")
-    tweet_status_id_str = CharField(null=True)
+    tweet_status_id_str = CharField(null=False, default="")
 
     @property
     def diff(self):
@@ -450,6 +450,17 @@ def get_initial_config():
             "access_token_secret": token[1],
         }
 
+    answer = input("Would you like to set up emailing edits? [Y/n] ")
+    if answer.lower() == "y":
+        print("Go to https://app.sendgrid.com/ and get an API key.")
+        api_key = input("What is the API key? ")
+        sender = input("What email address is sending the email? ")
+        receivers = input("Who are receiving the emails?  ")
+
+        config["sendgrid"] = {"api_key": api_key}
+
+        config["feeds"][0]["sendgrid"] = {"sender": sender, "receivers": receivers}
+
     print("Saved your configuration in %s/config.yaml" % home.rstrip("/"))
     print("Fetching initial set of entries.")
 
@@ -549,7 +560,7 @@ def main():
     lang = config.get("lang", {})
 
     try:
-        twitter_config = config.get("twitter")
+        twitter_config = config.get("twitter", {})
         twitter_handler = TwitterHandler(
             twitter_config["consumer_key"], twitter_config["consumer_secret"]
         )
@@ -560,16 +571,8 @@ def main():
         twitter_handler = None
         logging.warning("the twitter keys are not present in config. Reason", str(e))
 
-    try:
-        sendgrid_config = config.get("sendgrid")
-        sendgrid_handler = SendgridHandler(sendgrid_config)
-
-    except KeyError as e:
-        logging.warning(
-            "Sendgrid global configuration not set. Expecting configuration set per feed. Reason ",
-            str(e),
-        )
-        sendgrid_handler = SendgridHandler()
+    sendgrid_config = config.get("sendgrid", {})
+    sendgrid_handler = SendgridHandler(sendgrid_config)
 
     checked = skipped = new = 0
 
@@ -612,7 +615,8 @@ def process_entry(entry, feed_config, twitter=None, sendgrid=None, lang={}):
                 result["new"] = 1
                 if version.diff:
                     try:
-                        if token is not None:
+                        token = feed_config.get("twitter", {})
+                        if token:
                             twitter.tweet_diff(version.diff, token, lang)
                     except TwitterError as e:
                         logging.warning("error occurred while trying to tweet", str(e))

--- a/diffengine/sendgrid.py
+++ b/diffengine/sendgrid.py
@@ -1,0 +1,61 @@
+import logging
+
+from datetime import datetime
+from sendgrid import Mail, SendGridAPIClient
+
+from exceptions.sendgrid import (
+    AlreadyEmailedError,
+    ConfigNotFoundError,
+    AchiveUrlNotFoundError
+)
+
+
+class SendgridHandler:
+    api_token = None
+    sender = None
+    receivers = None
+
+    def __init__(self, config):
+
+        if not all(["api_token" in config, "sender" in config,
+                    "receivers" in config]):
+            raise ConfigNotFoundError()
+
+        self.api_token = config["api_token"]
+        self.sender = config["sender"]
+        self.receivers = config["receivers"]
+
+    def mailer(self):
+        return SendGridAPIClient(self.api_token)
+
+    def build_subject(self, diff):
+        return diff.old.title
+
+    def build_hmtl_body(self, diff):
+        body = None
+        with open(diff.html_path) as html_file:
+            body = html_file.read()
+
+        return body
+
+    def publish_diff(self, diff):
+        if diff.emailed:
+            raise AlreadyEmailedError(diff.id)
+        elif not (diff.old.archive_url and diff.new.archive_url):
+            raise AchiveUrlNotFoundError()
+
+        subject = self.build_subject(diff)
+        message = Mail(
+            from_email=self.sender,
+            to_emails=self.receivers,
+            subject=subject,
+            html_content=self.build_html_body(diff)
+        )
+
+        try:
+            self.mailer.send(message)
+            diff.emailed = datetime.utcnow()
+            logging.info("emailed %s", subject)
+            diff.save()
+        except Exception as e:
+            logging.error("unable to email: %s", e)

--- a/diffengine/sendgrid.py
+++ b/diffengine/sendgrid.py
@@ -6,7 +6,7 @@ from sendgrid import Mail, SendGridAPIClient
 from exceptions.sendgrid import (
     AlreadyEmailedError,
     ConfigNotFoundError,
-    AchiveUrlNotFoundError
+    ArchiveUrlNotFoundError,
 )
 
 
@@ -17,43 +17,50 @@ class SendgridHandler:
 
     def __init__(self, config):
 
-        if not all(["api_token" in config, "sender" in config,
-                    "receivers" in config]):
-            raise ConfigNotFoundError()
+        if not all(["api_token" in config, "sender" in config, "receivers" in config]):
+            logging.warning(
+                "No global config found for sendgrid, expecting config set for each feed"
+            )
 
-        self.api_token = config["api_token"]
-        self.sender = config["sender"]
-        self.receivers = config["receivers"]
+        self.api_token = config.get("api_token")
+        self.sender = config.get("sender")
+        self.receivers = config.get("receivers")
 
-    def mailer(self):
-        return SendGridAPIClient(self.api_token)
+    def mailer(self, api_token):
+        return SendGridAPIClient(api_token)
 
     def build_subject(self, diff):
         return diff.old.title
 
-    def build_hmtl_body(self, diff):
+    def build_html_body(self, diff):
         body = None
         with open(diff.html_path) as html_file:
             body = html_file.read()
 
         return body
 
-    def publish_diff(self, diff):
+    def publish_diff(self, diff, feed_config):
         if diff.emailed:
             raise AlreadyEmailedError(diff.id)
         elif not (diff.old.archive_url and diff.new.archive_url):
-            raise AchiveUrlNotFoundError()
+            raise ArchiveUrlNotFoundError()
+
+        api_token = (feed_config.get("api_token", self.api_token),)
+        sender = feed_config.get("sender", self.sender)
+        receivers = feed_config.get("receivers", self.receivers)
+        if not all([api_token, sender, receivers]):
+            raise ConfigNotFoundError
 
         subject = self.build_subject(diff)
         message = Mail(
-            from_email=self.sender,
-            to_emails=self.receivers,
+            from_email=sender,
+            to_emails=receivers,
             subject=subject,
-            html_content=self.build_html_body(diff)
+            html_content=self.build_html_body(diff),
         )
 
         try:
-            self.mailer.send(message)
+            self.mailer(api_token).send(message)
             diff.emailed = datetime.utcnow()
             logging.info("emailed %s", subject)
             diff.save()

--- a/diffengine/sendgrid.py
+++ b/diffengine/sendgrid.py
@@ -45,7 +45,7 @@ class SendgridHandler:
         elif not (diff.old.archive_url and diff.new.archive_url):
             raise ArchiveUrlNotFoundError()
 
-        api_token = (feed_config.get("api_token", self.api_token),)
+        api_token = feed_config.get("api_token", self.api_token)
         sender = feed_config.get("sender", self.sender)
         receivers = feed_config.get("receivers", self.receivers)
         if not all([api_token, sender, receivers]):

--- a/exceptions/sendgrid.py
+++ b/exceptions/sendgrid.py
@@ -6,7 +6,7 @@ class ConfigNotFoundError(SendgridError):
     """Exception raised if the Sendgrid instance has not the API key"""
 
     def __init__(self):
-        self.message = "API key not set up for feed."
+        self.message = "Config not set up for feed."
 
 
 class AlreadyEmailedError(SendgridError):
@@ -14,6 +14,6 @@ class AlreadyEmailedError(SendgridError):
         self.message = "diff %s was already emailed with sendgrid " % diff_id
 
 
-class AchiveUrlNotFoundError(SendgridError):
+class ArchiveUrlNotFoundError(SendgridError):
     def __init__(self):
         self.message = "not publishing without archive urls"

--- a/exceptions/sendgrid.py
+++ b/exceptions/sendgrid.py
@@ -1,0 +1,19 @@
+class SendgridError(RuntimeError):
+    pass
+
+
+class ConfigNotFoundError(SendgridError):
+    """Exception raised if the Sendgrid instance has not the API key"""
+
+    def __init__(self):
+        self.message = "API key not set up for feed."
+
+
+class AlreadyEmailedError(SendgridError):
+    def __init__(self, diff_id):
+        self.message = "diff %s was already emailed with sendgrid " % diff_id
+
+
+class AchiveUrlNotFoundError(SendgridError):
+    def __init__(self):
+        self.message = "not publishing without archive urls"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ feedparser
 readability-lxml
 envyaml>=0.1912
 pre-commit==2.3.0
+sendgrid


### PR DESCRIPTION
Sendgrid can be set up as a handler for publishing diffs. I have not updated the README as it looks unwiedly. I have kept the changes to the twitter handler minimal, and functionality should not be affected. 
tweet_status_id_str column in db is allowed to be empty now, as sendgrid does not set it up.

Refactoring to be discussed...