### PR TITLE
Added documentation and better support for multiple mail addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ regular updates. And with the [readability] module, diffengine is able to
 automatically extract the primary content of pages, without requiring special
 parsing to remove boilerplate material. And like NYTDiff, instead of creating
 another website for people to watch, diffengine pushes updates out to social
-media where people are already, while also building a local database of diffs
+media (via Twitter or email) where people are already, while also building a local database of diffs
 that can be used for research purposes.
 
 ## Install
@@ -42,7 +42,9 @@ directory in my home directory, but you can use whatever location you want, you
 just need to be able to write to it.
 
 The first time you run diffengine it will prompt you to enter an RSS or Atom
-feed URL to monitor and will authenticate with Twitter.
+feed URL to monitor. You will the be asked to provide the credentials to
+publish the diffs in social media.
+
 
 ```console
 % diffengine /home/ed/.diffengine
@@ -64,6 +66,16 @@ Visit https://api.twitter.com/oauth/authorize?oauth_token=NRW9BQAAAAAAyqBnAAXXYY
 What is your PIN: 8675309
 
 Saved your configuration in /home/ed/.diffengine/config.yaml
+
+Would you like to set up emailing edits with Sendgrid? [Y/n] y
+
+Go to https://app.sendgrid.com/ and get an API key.
+
+What is the API key? <API_KEY>
+
+What email address is sending the email? <FROM_ADDRESS>
+
+Who are the recipients of the emails?  <RECEIVERS ADDRESSES_CSV>
 
 Fetching initial set of entries.
 
@@ -140,11 +152,17 @@ If there are multiple feeds for an account, you can setup the `config.yml` like 
   twitter:
     access_token: ACCESS_TOKEN
     access_token_secret: ACCESS_TOKEN_SECRET
+  sendgrid:
+    sender: FROM_ADDRESS
+    recipients: TO_ADDRES1, TO_ADDRESS2
   url: http://www.theglobeandmail.com/report-on-business/?service=rss
 - name: The Globe and Mail - Opinion
   twitter:
     access_token: ACCESS_TOKEN
     access_token_secret: ACCESS_TOKEN_SECRET
+  sendgrid:
+    sender: FROM_ADDRESS2
+    recipients: TO_ADDRES3, TO_ADDRESS4
   url: http://www.theglobeandmail.com/opinion/?service=rss
 - name: The Globe and Mail - News
   twitter:
@@ -154,6 +172,8 @@ If there are multiple feeds for an account, you can setup the `config.yml` like 
 twitter:
   consumer_key: CONSUMER_KEY
   consumer_secret: CONSUMER_SECRET
+sendgrid:
+  api_token: API_TOKEN
 ```
 
 ### Skip entry

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -476,16 +476,16 @@ def get_initial_config():
             "access_token_secret": token[1],
         }
 
-    answer = input("Would you like to set up emailing edits? [Y/n] ")
+    answer = input("Would you like to set up emailing edits with Sendgrid? [Y/n] ")
     if answer.lower() == "y":
         print("Go to https://app.sendgrid.com/ and get an API key.")
         api_key = input("What is the API key? ")
         sender = input("What email address is sending the email? ")
-        receivers = input("Who are receiving the emails?  ")
+        recipients = input("Who are the recipients of the emails?  ")
 
         config["sendgrid"] = {"api_key": api_key}
 
-        config["feeds"][0]["sendgrid"] = {"sender": sender, "receivers": receivers}
+        config["feeds"][0]["sendgrid"] = {"sender": sender, "recipients": recipients}
 
     print("Saved your configuration in %s/config.yaml" % home.rstrip("/"))
     print("Fetching initial set of entries.")

--- a/diffengine/sendgrid.py
+++ b/diffengine/sendgrid.py
@@ -62,9 +62,13 @@ class SendgridHandler:
 
         subject = self.build_subject(diff)
         message = Mail(
-            from_email=sender, subject=subject, html_content=self.build_html_body(diff)
+            from_email=sender,
+            subject=subject,
+            to_emails=recipients.pop(0),
+            html_content=self.build_html_body(diff),
         )
-        message.bcc = recipients
+        if recipients:
+            message.bcc = recipients
         try:
             self.mailer(api_token).send(message)
             diff.emailed = datetime.utcnow()

--- a/diffengine/sendgrid.py
+++ b/diffengine/sendgrid.py
@@ -31,7 +31,7 @@ class SendgridHandler:
 
     def build_recipients(self, recipients):
         if recipients:
-            return [Bcc(x.strip()) for x in recipients.split(",")]
+            return [x.strip() for x in recipients.split(",")]
 
     def build_subject(self, diff):
         return diff.old.title

--- a/diffengine/sendgrid.py
+++ b/diffengine/sendgrid.py
@@ -1,7 +1,7 @@
 import logging
 
 from datetime import datetime
-from sendgrid import Mail, SendGridAPIClient
+from sendgrid import Mail, To, SendGridAPIClient
 
 from diffengine.exceptions.sendgrid import (
     AlreadyEmailedError,
@@ -13,21 +13,25 @@ from diffengine.exceptions.sendgrid import (
 class SendgridHandler:
     api_token = None
     sender = None
-    receivers = None
+    recipients = None
 
     def __init__(self, config):
 
-        if not all(["api_token" in config, "sender" in config, "receivers" in config]):
+        if not all(["api_token" in config, "sender" in config, "recipients" in config]):
             logging.warning(
                 "No global config found for sendgrid, expecting config set for each feed"
             )
 
         self.api_token = config.get("api_token")
         self.sender = config.get("sender")
-        self.receivers = config.get("receivers")
+        self.recipients = self.build_recipients(config.get("recipients"))
 
     def mailer(self, api_token):
         return SendGridAPIClient(api_token)
+
+    def build_recipients(self, recipients):
+        if recipients:
+            return [To(x.strip()) for x in recipients.split(",")]
 
     def build_subject(self, diff):
         return diff.old.title
@@ -47,14 +51,19 @@ class SendgridHandler:
 
         api_token = feed_config.get("api_token", self.api_token)
         sender = feed_config.get("sender", self.sender)
-        receivers = feed_config.get("receivers", self.receivers)
-        if not all([api_token, sender, receivers]):
+
+        recipients = None
+        if feed_config.get("recipients"):
+            recipients = self.build_recipients(feed_config.get("recipients"))
+        else:
+            recipients = self.recipients
+        if not all([api_token, sender, recipients]):
             raise SendgridConfigNotFoundError
 
         subject = self.build_subject(diff)
         message = Mail(
             from_email=sender,
-            to_emails=receivers,
+            to_emails=recipients,
             subject=subject,
             html_content=self.build_html_body(diff),
         )

--- a/diffengine/sendgrid.py
+++ b/diffengine/sendgrid.py
@@ -1,7 +1,7 @@
 import logging
 
 from datetime import datetime
-from sendgrid import Mail, To, SendGridAPIClient
+from sendgrid import Mail, Bcc, SendGridAPIClient
 
 from diffengine.exceptions.sendgrid import (
     AlreadyEmailedError,
@@ -31,7 +31,7 @@ class SendgridHandler:
 
     def build_recipients(self, recipients):
         if recipients:
-            return [To(x.strip()) for x in recipients.split(",")]
+            return [Bcc(x.strip()) for x in recipients.split(",")]
 
     def build_subject(self, diff):
         return diff.old.title
@@ -62,12 +62,9 @@ class SendgridHandler:
 
         subject = self.build_subject(diff)
         message = Mail(
-            from_email=sender,
-            to_emails=recipients,
-            subject=subject,
-            html_content=self.build_html_body(diff),
+            from_email=sender, subject=subject, html_content=self.build_html_body(diff)
         )
-
+        message.bcc = recipients
         try:
             self.mailer(api_token).send(message)
             diff.emailed = datetime.utcnow()

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -377,7 +377,7 @@ class EntryTest(TestCase):
         sendgrid_config = {
             "api_token": "12345",
             "sender": "test@test.test",
-            "receivers": "test@test.test",
+            "recipients": "test@test.test, test2@test.test",
         }
         result = process_entry(entry, {"sendgrid": sendgrid_config}, None, sendgrid)
 
@@ -582,7 +582,7 @@ class SendgridHandlerTest(TestCase):
         "sendgrid": {
             "api_token": "12345",
             "sender": "test@test.test",
-            "receivers": "test@test.test",
+            "recipients": "test@test.test, test2@test.test",
         }
     }
 

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -377,7 +377,7 @@ class EntryTest(TestCase):
         sendgrid_config = {
             "api_token": "12345",
             "sender": "test@test.test",
-            "recipients": "test@test.test, test2@test.test",
+            "recipients": "test@test.test",
         }
         result = process_entry(entry, {"sendgrid": sendgrid_config}, None, sendgrid)
 
@@ -638,6 +638,26 @@ class SendgridHandlerTest(TestCase):
             self.fail(
                 "sendgrid.publish_diff raised AchiveUrlNotFoundError unexpectedly!"
             )
+
+    def test_only_one_recipient(self):
+        config = {
+            "sendgrid": {
+                "api_token": "12345",
+                "sender": "sender@test.test",
+                "recipients": "recipient@test.test",
+            }
+        }
+
+        sendgrid = SendgridHandler(config["sendgrid"])
+
+        diff = get_mocked_diff(False)
+        type(diff.old).archive_url = PropertyMock(return_value="http://test.url/old")
+        type(diff.new).archive_url = PropertyMock(return_value="http://test.url/new")
+
+        try:
+            sendgrid.publish_diff(diff, config["sendgrid"])
+        except Exception as e:
+            self.fail(e)
 
 
 def get_mocked_diff(with_archive_urls=True):


### PR DESCRIPTION
Very light documentation added to mention email possibility, to show the config messages in  console during first run, and to include sengrid config in config.yaml example.

Now we send mails using BCC and not TO field, better for privacy.