### PR TITLE
Tweeting fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script: py.test
 before_install:
   - sudo apt-get -y update
   - sudo apt-get install firefox-geckodriver
-  - sudo apt-get install chromium-chromedriver=83
+  - sudo apt-get install chromium-chromedriver
 after_failure: cat test/diffengine.log
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script: py.test
 before_install:
   - sudo apt-get -y update
   - sudo apt-get install firefox-geckodriver
-  - sudo apt-get install chromium-chromedriver=81.0.4044.138
+  - sudo apt-get install chromium-chromedriver=83
 after_failure: cat test/diffengine.log
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ script: py.test
 before_install:
   - sudo apt-get -y update
   - sudo apt-get install firefox-geckodriver
-  - sudo apt-get install chromium-chromedriver
+before_script:
+  - wget https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip
+  - unzip chromedriver_linux64.zip -d /home/travis/virtualenv/python3.7.1/bin/
+  - export CHROME_BIN=chromium-browser
 after_failure: cat test/diffengine.log
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script: py.test
 before_install:
   - sudo apt-get -y update
   - sudo apt-get install firefox-geckodriver
-  - sudo apt-get install --upgrade chromium-chromedriver
+  - sudo apt-get install chromium-chromedriver=81.0.4044.138
 after_failure: cat test/diffengine.log
 notifications:
   slack:

--- a/diffengine/__init__.py
+++ b/diffengine/__init__.py
@@ -299,6 +299,18 @@ class Diff(BaseModel):
     blogged = DateTimeField(null=True)
 
     @property
+    def url_changed(self):
+        return self.old.url != self.new.url
+
+    @property
+    def title_changed(self):
+        return self.old.title != self.new.title
+
+    @property
+    def summary_changed(self):
+        return self.old.summary != self.new.summary
+
+    @property
     def html_path(self):
         # use prime number to spread across directories
         path = home_path("diffs/%s/%s.html" % ((self.id % 257), self.id))

--- a/diffengine/twitter.py
+++ b/diffengine/twitter.py
@@ -66,7 +66,7 @@ class TwitterHandler:
 
         # Check if the thread exists
         thread_status_id_str = None
-        if diff.old.entry.tweet_status_id_str is None:
+        if diff.old.entry.tweet_status_id_str == "":
             try:
                 thread_status_id_str = self.create_thread(
                     diff.old.entry, diff.old, token

--- a/test_diffengine.py
+++ b/test_diffengine.py
@@ -423,7 +423,7 @@ class TwitterHandlerTest(TestCase):
     ):
 
         entry = MagicMock()
-        type(entry).tweet_status_id_str = PropertyMock(return_value=None)
+        type(entry).tweet_status_id_str = PropertyMock(return_value="")
 
         diff = get_mocked_diff()
         type(diff.old).entry = entry


### PR DESCRIPTION
This fix recovers the ability to start a thread lost at #77 after the change made by @andresfib of the default value from `None` to `''` for the `tweet_status_id_str` columns.

@andresfib is this change actually needed? I don't see you use that column in your PR at all. Anyway, I've already change it to make it work again.

In the other hand, I've addede the magic props of `url_changed`, `title_changed`, `summary_changed` that I forgot to add to the `Diff` model. Those are used when all the lang terms are defined in order to build the text properly. I've just realized about that omission 🤦‍♂️

### Side note
It also includes a Travis CI fix as chrome stable version is now 83 and chromedriver at apt-get was 81 so I found a way to install the proper version in order for the CI to work again